### PR TITLE
ENH: Build MCRIBS MIRTK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,14 +98,9 @@ RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git &
     cd /tmp && rm -rf /tmp/*
 
 # Avoid hardcoding Python paths
+COPY scripts/fixpy.sh .
 RUN apt-get update && apt-get install -y --no-install-recommends file && \
-    sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk && \
-    for TOOL in $(find /opt/mirtk/lib/tools/ -exec file {} \; | grep text | cut -d: -f1); do \
-        echo $TOOL \
-        if [[ $(head -n1 $TOOL) == *"python" ]] then \
-            sed -i '1 c#! /usr/bin/env python' $TOOL \
-        fi; \
-    done
+    bash fixpy.sh /opt/mirtk
 
 ENV PATH="/opt/mirtk/bin:$PATH" \
     LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/opt/vtk/lib:/opt/itk/lib:${LD_LIBRARY_PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git &
     cd MCRIBS && git checkout bb57350a88c35487ae1ad2d33975ec83eaa15a45 && \
     mv MIRTK/MIRTK /tmp/MIRTK && \
     patch /tmp/MIRTK/Modules/Common/src/Parallel.cc /tmp/patches/Parallel.patch && \
-    patch MIRTK/CMake/Modules/FindTBB.cmake /tmp/patches/FindTBB.patch && \
+    patch /tmp/MIRTK/CMake/Modules/FindTBB.cmake /tmp/patches/FindTBB.patch && \
     mkdir /tmp/mirtk-build && cd /tmp/mirtk-build && \
     ITK_DIR=/opt/itk && VTK_DIR=/opt/vtk && \
     cmake  \
@@ -96,7 +96,7 @@ RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git &
     /tmp/MIRTK && \
     make -j $(nproc) install && \
     ldconfig && \
-    cd /tmp && rm -rf /tmp/MIRTK /tmp/mirtk-build
+    cd /tmp && rm -rf /tmp/*
 
 # Avoid hardcoding python path
 RUN sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ RUN mkdir /tmp/vtk-build && cd /tmp/vtk-build && \
 # /usr/bin/ld: ../../lib/libMIRTKPointSet.so.0.0.0: undefined reference to `LZ4_compress_HC_continue'
 COPY patch/FindTBB.patch patch/Parallel.patch /tmp/patches/
 RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git && \
-    cd MCRIBS && git checkout bb57350a88c35487ae1ad2d33975ec83eaa15a45 && \
-    mv MIRTK/MIRTK /tmp/MIRTK && \
+    cd MCRIBS && mv MIRTK/MIRTK /tmp/MIRTK && \
     patch /tmp/MIRTK/Modules/Common/src/Parallel.cc /tmp/patches/Parallel.patch && \
     patch /tmp/MIRTK/CMake/Modules/FindTBB.cmake /tmp/patches/FindTBB.patch && \
     mkdir /tmp/mirtk-build && cd /tmp/mirtk-build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,12 @@ RUN mkdir /tmp/vtk-build && cd /tmp/vtk-build && \
 # /usr/bin/ld: ../../lib/libMIRTKPointSet.so.0.0.0: undefined reference to `LZ4_decompress_safe'
 # /usr/bin/ld: ../../lib/libMIRTKPointSet.so.0.0.0: undefined reference to `LZ4_decompress_safe_continue'
 # /usr/bin/ld: ../../lib/libMIRTKPointSet.so.0.0.0: undefined reference to `LZ4_compress_HC_continue'
-RUN git clone --depth 1 https://github.com/BioMedIA/MIRTK.git && \
-    cd MIRTK && git submodule update --init -- Packages && \
+COPY patch/FindTBB.patch patch/Parallel.patch /tmp/patches/
+RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git && \
+    cd MCRIBS && git checkout bb57350a88c35487ae1ad2d33975ec83eaa15a45 && \
+    mv MIRTK/MIRTK /tmp/MIRTK && \
+    patch /tmp/MIRTK/Modules/Common/src/Parallel.cc /tmp/patches/Parallel.patch && \
+    patch MIRTK/CMake/Modules/FindTBB.cmake /tmp/patches/FindTBB.patch && \
     mkdir /tmp/mirtk-build && cd /tmp/mirtk-build && \
     ITK_DIR=/opt/itk && VTK_DIR=/opt/vtk && \
     cmake  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,14 @@ RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git &
     ldconfig && \
     cd /tmp && rm -rf /tmp/*
 
-# Avoid hardcoding python path
-RUN sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk
+# Avoid hardcoding Python paths
+RUN sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk && \
+    for TOOL in $(find /opt/mirtk/lib/tools/ -exec file {} \; | grep text | cut -d: -f1); do \
+        echo $TOOL \
+        if [[ $(head -n1 $tool) == *"python" ]]; then \
+            sed -i '1 c#! /usr/bin/env python' $TOOL \
+        fi \
+    done
+
 ENV PATH="/opt/mirtk/bin:$PATH" \
     LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/opt/vtk/lib:/opt/itk/lib:${LD_LIBRARY_PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,12 +98,13 @@ RUN git clone --depth 1 https://github.com/DevelopmentalImagingMCRI/MCRIBS.git &
     cd /tmp && rm -rf /tmp/*
 
 # Avoid hardcoding Python paths
-RUN sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk && \
+RUN apt-get update && apt-get install -y --no-install-recommends file && \
+    sed -i '1 c#! /usr/bin/env python' /opt/mirtk/bin/mirtk && \
     for TOOL in $(find /opt/mirtk/lib/tools/ -exec file {} \; | grep text | cut -d: -f1); do \
         echo $TOOL \
-        if [[ $(head -n1 $tool) == *"python" ]]; then \
+        if [[ $(head -n1 $TOOL) == *"python" ]] then \
             sed -i '1 c#! /usr/bin/env python' $TOOL \
-        fi \
+        fi; \
     done
 
 ENV PATH="/opt/mirtk/bin:$PATH" \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Medical Image Registration ToolKit (MIRTK)
 
 
-This builds MIRTK and its dependencies (ITK, VTK) from source.
+This builds the MCRIBS version of MIRTK (latest commit: https://github.com/DevelopmentalImagingMCRI/MCRIBS/commit/bb57350a88c35487ae1ad2d33975ec83eaa15a45) and its dependencies (ITK, VTK) from source.
 Additionally, a modified version of VTK 9.2.2 is used, following https://github.com/DevelopmentalImagingMCRI/MCRIBS/commit/e0daec6d0798659c54eeea6c2bb2e440ca3de089
 
 
@@ -18,3 +18,4 @@ To use `mirtk` tools in another Dockerfile, you will need to:
     - libpng-dev
     - libsuitesparse-dev
     - libtbb-dev
+

--- a/patch/FindTBB.patch
+++ b/patch/FindTBB.patch
@@ -1,0 +1,91 @@
+--- CMake/Modules/FindTBB.cmake	2023-02-03 13:49:56
++++ p/CMake/Modules/FindTBB.cmake	2023-02-03 13:49:16
+@@ -255,12 +255,15 @@
+ # ------------------------------------------------------------------------------
+ # Find common include directory 
+ #
+-# Looking for tbb/tbb_stddef.h because we use this path later to read this file
+-# in order to extract the version information. The tbb.h header should be in the
+-# same directory and is searched for separately as part of the "tbb" and "malloc"
+-# component search. The TBB_INCLUDE_DIR is then used as HINTS.
++# Looking for tbb/tbb_stddef.h or tbb/version.h because we use either of these paths
++# later to read this file in order to extract the version information. The tbb.h
++# header should be in the same directory and is searched for separately as part of
++# the "tbb" and "malloc" component search. The TBB_INCLUDE_DIR is then used as HINTS.
+ find_path(TBB_INCLUDE_DIR
+-  NAMES tbb/tbb_stddef.h
++  NAMES
++    oneapi/tbb/version.h
++    tbb/version.h  
++    tbb/tbb_stddef.h
+   HINTS ${TBB_ROOT}
+   PATH_SUFFIXES ${_TBB_INC_PATH_SUFFIXES}
+ )
+@@ -459,32 +462,48 @@
+ endif ()
+ 
+ # ------------------------------------------------------------------------------
+-# Extract library version from start of tbb_stddef.h
++# Extract library version from start of tbb_stddef.h (older versions) or version.h
+ if (TBB_INCLUDE_DIR)
+   if (NOT DEFINED TBB_VERSION_MAJOR OR
+       NOT DEFINED TBB_VERSION_MINOR OR
+       NOT DEFINED TBB_INTERFACE_VERSION OR
+       NOT DEFINED TBB_COMPATIBLE_INTERFACE_VERSION)
+-    file(READ "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h" _TBB_VERSION_CONTENTS LIMIT 2048)
+-    string(REGEX REPLACE
+-      ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+-      TBB_VERSION_MAJOR "${_TBB_VERSION_CONTENTS}"
+-    )
+-    string(REGEX REPLACE
+-      ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+-      TBB_VERSION_MINOR "${_TBB_VERSION_CONTENTS}"
+-    )
+-    string(REGEX REPLACE
+-      ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+-      TBB_INTERFACE_VERSION "${_TBB_VERSION_CONTENTS}"
+-    )
+-    string(REGEX REPLACE
+-      ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
+-      TBB_COMPATIBLE_INTERFACE_VERSION "${_TBB_VERSION_CONTENTS}"
+-    )
+     unset(_TBB_VERSION_CONTENTS)
++    foreach (_TBB_VERSION_RELPATH IN ITEMS "oneapi/tbb/version.h" "tbb/version.h" "tbb_stddef.h")
++      if (EXISTS "${TBB_INCLUDE_DIR}/${_TBB_VERSION_RELPATH}")
++        if (TBB_DEBUG)
++          message("** FindTBB: Extract version information from ${TBB_INCLUDE_DIR}/${_TBB_VERSION_RELPATH}")
++        endif ()
++        file(READ "${TBB_INCLUDE_DIR}/${_TBB_VERSION_RELPATH}" _TBB_VERSION_CONTENTS LIMIT 2048)
++        break()
++      endif ()
++    endforeach ()
++    if (_TBB_VERSION_CONTENTS MATCHES "TBB_VERSION_MAJOR")
++      string(REGEX REPLACE
++        ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
++        TBB_VERSION_MAJOR "${_TBB_VERSION_CONTENTS}"
++      )
++      string(REGEX REPLACE
++        ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
++        TBB_VERSION_MINOR "${_TBB_VERSION_CONTENTS}"
++      )
++      string(REGEX REPLACE
++        ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
++        TBB_INTERFACE_VERSION "${_TBB_VERSION_CONTENTS}"
++      )
++      string(REGEX REPLACE
++        ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
++        TBB_COMPATIBLE_INTERFACE_VERSION "${_TBB_VERSION_CONTENTS}"
++      )
++    endif ()
++    unset(_TBB_VERSION_CONTENTS)
++    unset(_TBB_VERSION_RELPATH)
+   endif ()
+-  set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
++  if (TBB_VERSION_MAJOR AND TBB_VERSION_MINOR)
++    set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
++  else ()
++    set(TBB_VERSION "")
++  endif ()
+   set(TBB_VERSION_STRING "${TBB_VERSION}")
+ else ()
+   unset(TBB_VERSION)

--- a/patch/Parallel.patch
+++ b/patch/Parallel.patch
@@ -1,0 +1,15 @@
+--- Modules/Common/src/Parallel.cc	2023-02-03 13:55:17
++++ p/Modules/Common/src/Parallel.cc	2023-02-03 13:54:48
+@@ -18,7 +18,11 @@
+  */
+ 
+ #ifdef HAVE_TBB
+-#  include <tbb/tbb_stddef.h>
++#  if __has_include("tbb/tbb_stddef.h")
++#    include <tbb/tbb_stddef.h>
++#  else
++#    include <tbb/version.h>
++#  endif
+ #endif
+ 
+ #include "mirtk/Parallel.h"

--- a/scripts/fixpy.sh
+++ b/scripts/fixpy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+MIRTKDIR=$1
+
+for TOOL in $(find $MIRTKDIR/lib/tools/ -exec file {} \; | grep text | cut -d: -f1) $MIRTKDIR/bin/mirtk; do
+    if [[ $(head -n1 $TOOL) == *"python" ]]; then
+        sed -i '1 c#! /usr/bin/env python' $TOOL && echo "Fixed: $TOOL";
+    fi
+done


### PR DESCRIPTION
The MCRIBS MIRTK includes additional support for the deformable package, which houses the `recon-neonatal-cortex` used in nibabies.